### PR TITLE
Support es6 imports

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,4 +7,4 @@ function safeGet() {
     return lodashGet(obj, path);
 }
 
-module.exports.default = safeGet;
+module.exports = module.exports.default = safeGet;


### PR DESCRIPTION
When importing this from webpack using es6 imports, I imported this as:

```js
import getSafe from 'ts-get-safe';
```
but when I inspect the object, getSafe appears as `{ default: safeGet }`

The pattern here is what I have seen in other modules to make this work in multiple import systems.